### PR TITLE
Fix docker image generation in Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 /package-lock.json
 /yarn-error.log
 /lerna-debug.log
+/Dockerfile-dev

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ jquery:
 	cat /tmp/jquery/dist/jquery.min.js | perl -pe 's|"3\..+?"|"3"|' > $(CURDIR)/client/jquery-custom.min.js
 	rm -rf /tmp/jquery
 
+Dockerfile-dev: Dockerfile
+	cat Dockerfile | sed -e 's/^RUN git clone.*/COPY [ ".", "\/droppy" ]/' > Dockerfile-dev
+
+docker-dev: Dockerfile-dev
+	docker build -t localhost/local/droppy-dev -f Dockerfile-dev .
+
 patch: test build ver-patch docker publish
 minor: test build ver-minor docker publish
 major: test build ver-major docker publish

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -5,7 +5,7 @@
 
 # echo >> /etc/xxx and not adduser/addgroup because adduser/addgroup
 # won't work if uid/gid already exists.
-echo -e "droppy:x:${UID}:${GID}:droppy:/droppy:/bin/false\n" >> /etc/passwd
+echo -e "droppy:x:${UID}:${GID}:droppy:/home/droppy:/bin/false\n" >> /etc/passwd
 echo -e "droppy:x:${GID}:droppy\n" >> /etc/group
 
 # it's better to do that (mkdir and chown) here than in the Dockerfile
@@ -13,7 +13,16 @@ echo -e "droppy:x:${GID}:droppy\n" >> /etc/group
 mkdir -p /config
 mkdir -p /files
 
+mkdir -p /home/droppy/.droppy
+
+ln -s /config /home/droppy/.droppy/config
+ln -s /files /home/droppy/.droppy/files
+
+chown -R droppy:droppy /home/droppy
+
 chown -R droppy:droppy /config
 chown droppy:droppy /files
 
-exec /bin/su -p -s "/bin/sh" -c "exec /usr/bin/droppy start --color -f /files -c /config" droppy
+export HOME=/home/droppy
+
+exec /bin/su -l -p -s "/bin/sh" -c "exec node /droppy/cli/lib/cli.js start" droppy


### PR DESCRIPTION
Closes: #4 

### What are the changes and their implications?

* There is a new Dockerfile
* docker-start.sh has been modified to reflect the changes
* The Dockerfile doesn't use working copy, but use source from https://github.com/droppy-js/droppy
* The Makefile is able to generate Dockerfile-dev which works like Dockerfile but for working copy

The resulting image has been tested with parametrized UID and GID, and it works as expected.

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [droppy-js.com](https://github.com/droppy-js/droppy-js.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
