### PR TITLE
Github action to build docker images on branch pushs and on tags

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,84 @@
+name: 'build-docker'
+
+on:
+    push:
+        branches:
+            - '*'
+        tags:
+            - 'v*'
+
+jobs:
+    build:
+        name: 'Build docker images'
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Checkout"
+              uses: actions/checkout@v2
+
+            - name: "Set env vars"
+              id: vars
+              run: |
+                  echo "GITHUB_SHA_SHORT=$(echo ${GITHUB_SHA} | cut -c1-8)" >> "${GITHUB_ENV}"
+                  echo "IMAGE_NAME=$(echo "ghcr.io/${{ secrets.CR_USER }}/droppy")" >> "${GITHUB_ENV}"
+                  echo "REFNAME=$(echo "${{ github.ref }}" | sed -e 's/.*\///')" >> "${GITHUB_ENV}"
+                  echo "TAGNAME=$(echo "${{ github.ref }}" | sed -e 's/.*\/v//')" >> "${GITHUB_ENV}"
+
+            - name: 'Login to github container registry'
+              uses: docker/login-action@v1
+              with:
+                  registry: ghcr.io
+                  username: ${{ secrets.CR_USER }}
+                  password: ${{ secrets.CR_PAT }}
+
+            - name: Make Dockerfile-dev
+              run: |
+                  make Dockerfile-dev
+
+            - name: Set the tag name in package.json if tag
+              if: "contains(github.ref, 'refs/tags')"
+              run: |
+                  sed -i -E 's/^ *\t*"version": *"([^"]*)",.*/    "version": "\1", "tag": "'"${{ env.TAGNAME }}"'",/' packages/server/package.json
+
+            - name: Set the git revision in package.json if not tag
+              if: "!contains(github.ref, 'refs/tags')"
+              run: |
+                  sed -i -E 's/^ *\t*"version": *"([^"]*)",.*/    "version": "\1", "tag": "'"${{ env.GITHUB_SHA_SHORT }}"'",/' packages/server/package.json
+
+            - name: "Build image ${{ env.IMAGE_NAME }} ${{ env.GITHUB_SHA_SHORT }}"
+              uses: docker/build-push-action@v2
+              with:
+                  push: false
+                  no-cache: true
+                  file: "Dockerfile-dev"
+                  context: "."
+                  tags: ${{ env.IMAGE_NAME }}:working
+
+            - name: "Tag using git version"
+              if: "!contains(github.ref, 'refs/tags')"
+              run: |
+                  docker tag "${{ env.IMAGE_NAME }}:working" "${{ env.IMAGE_NAME }}:${{ env.GITHUB_SHA_SHORT }}"
+                  docker push "${{ env.IMAGE_NAME }}:${{ env.GITHUB_SHA_SHORT }}"
+
+            - name: "Tag using git tag version or branch"
+              run: |
+                  docker tag "${{ env.IMAGE_NAME }}:working" "${{ env.IMAGE_NAME }}:${{ env.REFNAME }}"
+                  docker push "${{ env.IMAGE_NAME }}:${{ env.REFNAME }}"
+
+            - name: "Tag latest if release"
+              if: "contains(github.ref, 'refs/tags')"
+              run: |
+                  docker tag "${{ env.IMAGE_NAME }}:working" "${{ env.IMAGE_NAME }}:latest"
+                  docker push "${{ env.IMAGE_NAME }}:latest"
+
+            - name: "Create release"
+              if: "contains(github.ref, 'refs/tags')"
+              id: "create_release"
+              uses: "actions/create-release@v1"
+              env:
+                  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+              with:
+                  tag_name: "${{ github.ref }}"
+                  release_name: "Release ${{ github.ref }}"
+                  draft: false
+                  prerelease: false
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 /package-lock.json
 /yarn-error.log
 /lerna-debug.log
+/Dockerfile-dev

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ jquery:
 	cat /tmp/jquery/dist/jquery.min.js | perl -pe 's|"3\..+?"|"3"|' > $(CURDIR)/client/jquery-custom.min.js
 	rm -rf /tmp/jquery
 
+Dockerfile-dev: Dockerfile
+	cat Dockerfile | sed -e 's/^RUN git clone.*/COPY [ ".", "\/droppy" ]/' > Dockerfile-dev
+
+docker-dev: Dockerfile-dev
+	docker build -t localhost/local/droppy-dev -f Dockerfile-dev .
+
 patch: test build ver-patch docker publish
 minor: test build ver-minor docker publish
 major: test build ver-major docker publish

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -5,7 +5,7 @@
 
 # echo >> /etc/xxx and not adduser/addgroup because adduser/addgroup
 # won't work if uid/gid already exists.
-echo -e "droppy:x:${UID}:${GID}:droppy:/droppy:/bin/false\n" >> /etc/passwd
+echo -e "droppy:x:${UID}:${GID}:droppy:/home/droppy:/bin/false\n" >> /etc/passwd
 echo -e "droppy:x:${GID}:droppy\n" >> /etc/group
 
 # it's better to do that (mkdir and chown) here than in the Dockerfile
@@ -13,7 +13,16 @@ echo -e "droppy:x:${GID}:droppy\n" >> /etc/group
 mkdir -p /config
 mkdir -p /files
 
+mkdir -p /home/droppy/.droppy
+
+ln -s /config /home/droppy/.droppy/config
+ln -s /files /home/droppy/.droppy/files
+
+chown -R droppy:droppy /home/droppy
+
 chown -R droppy:droppy /config
 chown droppy:droppy /files
 
-exec /bin/su -p -s "/bin/sh" -c "exec /usr/bin/droppy start --color -f /files -c /config" droppy
+export HOME=/home/droppy
+
+exec /bin/su -l -p -s "/bin/sh" -c "exec node /droppy/cli/lib/cli.js start" droppy

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   droppy:
     container_name: droppy
-    image: silverwind/droppy
+    image: ghcr.io/droppy-js/droppy
     ports:
       - '127.0.0.1:8989:8989'
     volumes:

--- a/packages/client/lib/style.css
+++ b/packages/client/lib/style.css
@@ -1685,7 +1685,7 @@ video {
     position: fixed;
     transition: .15s, visibility 0s .15s;
     transform: translate(-50%, -50%);
-    width: 300px;
+    width: 400px;
     text-align: center;
     z-index: 64;
 }
@@ -1713,7 +1713,7 @@ video {
     bottom: 0;
     font-size: .7em;
     margin-bottom: .2em;
-    width: 300px;
+    width: 100%;
     position: absolute;
 }
 

--- a/packages/server/lib/server.js
+++ b/packages/server/lib/server.js
@@ -448,7 +448,7 @@ function onWebSocketRequest(ws, req) {
                 vId,
                 settings: {
                     priv,
-                    version: pkg.version,
+                    version: pkg.tag && (pkg.tag !== pkg.version) ? `${pkg.version} (${pkg.tag})` : pkg.version,
                     dev: config.dev,
                     public: config.public,
                     readOnly: config.readOnly,


### PR DESCRIPTION
Closes: #6 

### What are the changes and their implications?

* A new github action has been created to build new docker image and upload them to the github container registry (ghcr.io).
* On each push on branch, a new docker image is created labeled with both the git revision (ex: 4f8daa1b02) and the branch name (ex: canary, master)
* On each tag, a new docker image is created labeled with tag name (ex: v13.0.1) and with "latest"
  * Simple commit without tag will never impact latest tag. Only tags will impact it.
* In the about box of the application running in the docker image, a new information will be prompted along side the version. 
  * If the docker image has been generated from a push on a branch, the git revision will be prompt (ex: "Version 13.0.1 (4f8daa1b02)")
  * If the docker image has been generated from a tag, if the @droppy-js/server project version is different from the tag, the tag will be prompt (ex: "Version 0.0.0 (13.0.1)")
  * In all other cases, including dev version and releases not generated by this github action, only the @droppy-js/server project version will be prompt (ex: "Version 13.0.1")

### Requierements

Two secrets should be created in order for this github action to work:
* **CR_USER** : The organisation/user name (ex: droppy-js)
* **CR_PAT**: A personal access token with `write:packages` right to create packages on the organisation/user space

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [droppy-js.com](https://github.com/droppy-js/droppy-js.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
