### PR TITLE
Fix/9 mp3 play

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "node": ">= 12.10.0"
     },
     "scripts": {
-        "start": "lerna run start --stream",
+        "start": "lerna run --stream start --",
         "bootstrap": "lerna bootstrap",
         "test": "make test"
     },

--- a/packages/client/lib/client.js
+++ b/packages/client/lib/client.js
@@ -2506,16 +2506,17 @@ function initAudio(view) {
     event.stopPropagation();
   });
 
-  function setVolume(view, volume) {
+  function setVolume(volume) {
     if (volume > 1) volume = 1;
     if (volume < 0) volume = 0;
+
     player.volume = volume;
     droppy.set("volume", volume);
     if (player.volume === 0) volumeIcon.html(svg("volume-mute"));
     else if (player.volume <= 0.33) volumeIcon.html(svg("volume-low"));
     else if (player.volume <= 0.67) volumeIcon.html(svg("volume-medium"));
     else volumeIcon.html(svg("volume-high"));
-    view.find(".volume-slider-inner")[0].style.width = `${volume * 100}%`;
+    document.querySelector('.volume-slider-inner').style.width = `${volume * 100}%`;
   }
 
   function onWheel(event) {

--- a/packages/client/lib/client.js
+++ b/packages/client/lib/client.js
@@ -2516,7 +2516,7 @@ function initAudio(view) {
     else if (player.volume <= 0.33) volumeIcon.html(svg("volume-low"));
     else if (player.volume <= 0.67) volumeIcon.html(svg("volume-medium"));
     else volumeIcon.html(svg("volume-high"));
-    document.querySelector('.volume-slider-inner').style.width = `${volume * 100}%`;
+    document.querySelector(".volume-slider-inner").style.width = `${volume * 100}%`;
   }
 
   function onWheel(event) {

--- a/packages/server/lib/resources.js
+++ b/packages/server/lib/resources.js
@@ -96,7 +96,7 @@ let autoprefixer, cleanCSS, postcss, terser, htmlMinifier, svg, handlebars;
 try {
   autoprefixer = require("autoprefixer");
   cleanCSS = new (require("clean-css"))(opts.cleanCSS);
-//  handlebars = require("handlebars");
+  handlebars = require("handlebars");
   htmlMinifier = require("html-minifier");
   postcss = require("postcss");
   terser = require("terser");

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,7 @@
         "daemonize-process": "3.0.0",
         "escape-string-regexp": "4.0.0",
         "etag": "1.8.1",
+        "handlebars": "^4.7.7",
         "image-size": "0.8.3",
         "isbinaryfile": "4.0.6",
         "json-buffer": "3.0.1",


### PR DESCRIPTION
Closes: #9

### What are the changes and their implications?

For some reason the `setVolume` function was expecting a first param `view`. This was never passed properly. Instead, it was removed and the functionality replace with `document.querySelector`

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [droppy-js.com](https://github.com/droppy-js/droppy-js.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
