### PR TITLE
Update docker-start.sh

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -3,40 +3,47 @@
 #
 #           .:.
 #    :::  .:::::.    Droppy
-#  ..:::..  :::      Made with love <3 
-#   ':::'   :::      
+#  ..:::..  :::      Made with love <3
+#   ':::'   :::
 #     '
 #
 
 
 # Determine a UID/GID otherwise default to 0
-[ -z "$UID" ] && UID=0
-[ -z "$GID" ] && GID=0
+[ -z "${UID}" ] && UID=0
+[ -z "${GID}" ] && GID=0
 
-# echo >> /etc/xxx and not adduser/addgroup because adduser/addgroup
-# won't work if uid/gid already exists.
-echo "droppy:x:${UID}:${GID}:droppy:/home/droppy:/bin/false\n" >> /etc/passwd
-echo "droppy:x:${GID}:droppy\n" >> /etc/group
+FILE="/droppy/UID-${UID}_GID-${GID}"
+if [ ! -f "${FILE}" ]; then
+  # echo >> /etc/xxx and not adduser/addgroup because adduser/addgroup
+  # won't work if uid/gid already exists.
+  echo -e "droppy:x:${UID}:${GID}:droppy:/home/droppy:/bin/false" >> /etc/passwd
+  echo -e "droppy:x:${GID}:droppy" >> /etc/group
 
-# create shadow files from /etc/passwd and /etc/group
-grpconv
-pwconv
+  # create shadow files from /etc/passwd and /etc/group
+  grpconv
+  pwconv
 
-# it's better to do that (mkdir and chown) here than in the Dockerfile
-# because it will be executed even on volumes if mounted.
-mkdir -p /config
-mkdir -p /files
+  # it's better to do that (mkdir and chown) here than in the Dockerfile
+  # because it will be executed even on volumes if mounted.
+  mkdir -p /config
+  mkdir -p /files
 
-mkdir -p /home/droppy/.droppy
+  mkdir -p /home/droppy/.droppy
 
-ln -s /config /home/droppy/.droppy/config
-ln -s /files /home/droppy/.droppy/files
+  ln -s /config /home/droppy/.droppy/config
+  ln -s /files /home/droppy/.droppy/files
 
-chown -R droppy:droppy /home/droppy
+  chown -R droppy:droppy /home/droppy
 
-chown -R droppy:droppy /config
-chown droppy:droppy /files
+  chown -R droppy:droppy /config
+  chown droppy:droppy /files
 
-export HOME=/home/droppy
+  export HOME=/home/droppy
 
-exec /bin/sudo -u droppy node /droppy/cli/lib/cli.js start
+  volta install node
+
+  touch "${FILE}"
+fi
+
+exec /bin/su droppy -s /bin/bash -c "node /droppy/packages/cli/lib/cli.js start"


### PR DESCRIPTION
Closes: Docker container failed at startup

### What are the changes and their implications?
- On docker container start (command)
  - droppy user and group are only added, if not already exists
  - Node is will be installed (only once)
  - Webserver will be started correctly with droppy user
### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [droppyjs.com](https://github.com/droppyjs/droppyjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
