### PR TITLE
fix: aspect ratio of rotated images

### DIFF
--- a/packages/server/lib/commands/getMedia.js
+++ b/packages/server/lib/commands/getMedia.js
@@ -19,12 +19,21 @@ exports.default = {
         if (utils.extensionRe(exts.pdf).test(file)) {
           resolve({pdf: true, src: file});
         } else if (utils.extensionRe(exts.img).test(file)) {
-          imgSize(path.join(utils.addFilesPath(dir), file), (err, dims) => {
+          imgSize(path.join(utils.addFilesPath(dir), file), (err, dims, width, height) => {
             if (err) log.error(err);
+
+            if (dims.orientation === 6 || dims.orientation === 8) {
+              height = dims && dims.width;
+              width = dims && dims.height;
+            } else {
+              width = dims && dims.width;
+              height = dims && dims.height;
+            }
+
             resolve({
               src: file,
-              w: dims && dims.width ? dims.width : 0,
-              h: dims && dims.height ? dims.height : 0,
+              w: width ? width : 0,
+              h: height ? height : 0,
             });
           });
         } else {


### PR DESCRIPTION
Closes: https://github.com/droppyjs/droppy/issues/46

### What are the changes and their implications?

When an image is orientated 90 degrees to the left or the right, the width and the height is rotated as well.

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [x] PR submitted to [droppyjs.com](https://github.com/droppyjs/droppyjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
