### PR TITLE
fix paths

### DIFF
--- a/packages/server/lib/services/cfg.js
+++ b/packages/server/lib/services/cfg.js
@@ -8,7 +8,7 @@ const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
 const mkdir = promisify(fs.mkdir);
 
-const configFile = require("./paths.js").get().cfgFile;
+const paths = require("./paths.js");
 
 const defaults = {
   listeners: [{
@@ -38,6 +38,7 @@ const hiddenOpts = ["dev"];
 const cfg = module.exports = {};
 
 cfg.init = (config) => new Promise(async (resolve, reject) => {
+  const configFile = paths.get().cfgFile;
   if (typeof config === "object" && config !== null) {
     config = Object.assign({}, defaults, config);
     return resolve(config);
@@ -49,7 +50,7 @@ cfg.init = (config) => new Promise(async (resolve, reject) => {
         config = defaults;
         await mkdir(dirname(configFile), {recursive: true});
 
-        await write(config);
+        await write(configFile, config);
         resolve(config);
       } else {
         return reject(err);
@@ -79,7 +80,7 @@ cfg.init = (config) => new Promise(async (resolve, reject) => {
           delete config[key];
         }
       });
-      await write(config);
+      await write(configFile, config);
       return resolve(config);
     } catch (err) {
       // TODO: can we print helpful information here?
@@ -88,7 +89,7 @@ cfg.init = (config) => new Promise(async (resolve, reject) => {
   }
 });
 
-function write(config) {
+function write(configFile, config) {
   return new Promise((resolve, reject) => {
     fs.writeFile(configFile, JSON.stringify(config, null, 2), (err) => {
       if (err) {

--- a/packages/server/lib/services/db.js
+++ b/packages/server/lib/services/db.js
@@ -7,12 +7,13 @@ const crypto = require("crypto");
 const path = require("path");
 
 const log = require("./log.js");
-const dbFile = require("./paths.js").get().db;
+const paths = require("./paths.js");
 const defaults = {users: {}, sessions: {}, links: {}};
 
 let database, watching;
 
 db.load = function(callback) {
+  const dbFile = paths.get().db;
   fs.stat(dbFile, err => {
     if (err) {
       if (err.code === "ENOENT") {
@@ -77,6 +78,7 @@ db.load = function(callback) {
 };
 
 db.parse = function(cb) {
+  const dbFile = paths.get().db;
   fs.readFile(dbFile, "utf8", (err, data) => {
     if (err) return cb(err);
 
@@ -147,6 +149,7 @@ db.authUser = function(user, pass) {
 };
 
 db.watch = function(config) {
+  const dbFile = paths.get().db;
   chokidar.watch(dbFile, {
     ignoreInitial: true,
     usePolling: Boolean(config.pollingInterval),
@@ -165,6 +168,7 @@ db.watch = function(config) {
 
 // TODO: async
 function write() {
+  const dbFile = paths.get().db;
   watching = false;
   fs.writeFileSync(dbFile, JSON.stringify(database, null, 2));
 

--- a/packages/server/lib/services/filetree.js
+++ b/packages/server/lib/services/filetree.js
@@ -12,7 +12,7 @@ const rfdc = require("rfdc");
 const util = require("util");
 
 const log = require("./log.js");
-const paths = require("./paths.js").get();
+const paths = require("./paths.js");
 const utils = require("./utils.js");
 
 const clone = rfdc();
@@ -32,7 +32,7 @@ filetree.init = function(config) {
 };
 
 filetree.watch = function() {
-  chokidar.watch(paths.files, {
+  chokidar.watch(paths.get().files, {
     alwaysStat: true,
     ignoreInitial: true,
     usePolling: Boolean(cfg.pollingInterval),

--- a/packages/server/lib/services/resources.js
+++ b/packages/server/lib/services/resources.js
@@ -11,12 +11,12 @@ const {stat, mkdir, readdir, readFile, writeFile} = require("fs").promises;
 const {promisify} = require("util");
 
 const log = require("./log.js");
-const paths = require("./paths.js").get();
+const paths = require("./paths.js");
 const utils = require("./utils.js");
 
-const themesPath = path.join(paths.client, "/node_modules/codemirror/theme");
-const modesPath = path.join(paths.client, "/node_modules/codemirror/mode");
-const cachePath = process.env.DROPPY_CACHE_PATH ?? path.join(paths.homedir, "/.droppy/cache/cache.json");
+const themesPath = path.join(paths.get().client, "/node_modules/codemirror/theme");
+const modesPath = path.join(paths.get().client, "/node_modules/codemirror/mode");
+const cachePath = process.env.DROPPY_CACHE_PATH ?? path.join(paths.get().homedir, "/.droppy/cache/cache.json");
 
 const pkg = require("../../package.json");
 
@@ -107,10 +107,10 @@ try {
 
 resources.files = {
   css: [
-    `${paths.client}/lib/style.css`,
-    `${paths.client}/lib/sprites.css`,
-    `${paths.client}/lib/tooltips.css`,
-    `${paths.client}/lib/clienttheme.css`,
+    `${paths.get().client}/lib/style.css`,
+    `${paths.get().client}/lib/sprites.css`,
+    `${paths.get().client}/lib/tooltips.css`,
+    `${paths.get().client}/lib/clienttheme.css`,
   ],
   js: [
     "node_modules/handlebars/dist/handlebars.runtime.min.js",
@@ -229,8 +229,8 @@ async function isCacheFresh(cb) {
   const files = [];
   for (const type of Object.keys(resources.files)) {
     resources.files[type].forEach(file => {
-      if (fs.existsSync(path.join(paths.client, file))) {
-        files.push(path.join(paths.client, file));
+      if (fs.existsSync(path.join(paths.get().client, file))) {
+        files.push(path.join(paths.get().client, file));
       } else {
         files.push(file);
       }
@@ -239,15 +239,15 @@ async function isCacheFresh(cb) {
 
   for (const file of Object.keys(libs)) {
     if (typeof libs[file] === "string") {
-      if (fs.existsSync(path.join(paths.client, libs[file]))) {
-        files.push(path.join(paths.client, libs[file]));
+      if (fs.existsSync(path.join(paths.get().client, libs[file]))) {
+        files.push(path.join(paths.get().client, libs[file]));
       } else {
         files.push(libs[file]);
       }
     } else {
       libs[file].forEach(file => {
-        if (fs.existsSync(path.join(paths.client, file))) {
-          files.push(path.join(paths.client, file));
+        if (fs.existsSync(path.join(paths.get().client, file))) {
+          files.push(path.join(paths.get().client, file));
         } else {
           files.push(file);
         }
@@ -324,7 +324,7 @@ async function readThemes() {
     themes[name.replace(/\.css$/, "")] = Buffer.from(await minifyCSS(String(data)));
   }
 
-  const droppyTheme = await readFile(path.join(paths.client, "/lib/cmtheme.css"));
+  const droppyTheme = await readFile(path.join(paths.get().client, "/lib/cmtheme.css"));
   themes.droppy = Buffer.from(await minifyCSS(String(droppyTheme)));
 
   return themes;
@@ -334,7 +334,7 @@ async function readModes() {
   const modes = {};
 
     // parse meta.js from CM for supported modes
-  const js = await readFile(path.join(paths.client, "/node_modules/codemirror/mode/meta.js"));
+  const js = await readFile(path.join(paths.get().client, "/node_modules/codemirror/mode/meta.js"));
 
     // Extract modes from CodeMirror
   const sandbox = {CodeMirror: {}};
@@ -357,7 +357,7 @@ async function readLibs() {
 
   for (const [dest, files] of Object.entries(libs)) {
     lib[dest] = Buffer.concat(await Promise.all(files.map(file => {
-      return readFile(path.join(paths.client, file));
+      return readFile(path.join(paths.get().client, file));
     })));
   }
 
@@ -397,8 +397,8 @@ function templates() {
         "templates=Handlebars.templates=Handlebars.templates||{};";
   const suffix = "Handlebars.partials=Handlebars.templates})();";
 
-  return prefix + fs.readdirSync(paths.templates).map(file => {
-    const p = path.join(paths.templates, file);
+  return prefix + fs.readdirSync(paths.get().templates).map(file => {
+    const p = path.join(paths.get().templates, file);
     const name = file.replace(/\..+$/, "");
     let html = htmlMinifier.minify(fs.readFileSync(p, "utf8"), opts.htmlMinifier);
 
@@ -421,8 +421,8 @@ function templates() {
 resources.compileJS = async function() {
   let js = "";
   resources.files.js.forEach(file => {
-    if (fs.existsSync(path.join(paths.client, file))) {
-      js += `${fs.readFileSync(path.join(paths.client, file), "utf8")};`;
+    if (fs.existsSync(path.join(paths.get().client, file))) {
+      js += `${fs.readFileSync(path.join(paths.get().client, file), "utf8")};`;
     } else {
       js += `${fs.readFileSync(file, "utf8")};`;
     }
@@ -458,7 +458,7 @@ resources.compileCSS = async function() {
 };
 
 resources.compileHTML = async function(res) {
-  let html = fs.readFileSync(path.join(paths.client, "lib", "index.html"), "utf8");
+  let html = fs.readFileSync(path.join(paths.get().client, "lib", "index.html"), "utf8");
   html = html.replace("<!-- {{svg}} -->", svg());
 
   let auth = html.replace("{{type}}", "a");
@@ -485,7 +485,7 @@ async function compileAll() {
     // Read misc files
   for (const file of resources.files.other) {
     const name = path.basename(file);
-    const fullPath = path.join(paths.client, file);
+    const fullPath = path.join(paths.get().client, file);
     const data = fs.readFileSync(fullPath);
     res[name] = {data, etag: etag(data), mime: utils.contentType(name)};
   }

--- a/packages/server/lib/services/svg.js
+++ b/packages/server/lib/services/svg.js
@@ -3,7 +3,7 @@
 const svgstore = require("@droppyjs/svgstore");
 const fs = require("fs");
 const path = require("path");
-const paths = require("./paths.js").get();
+const paths = require("./paths.js");
 
 module.exports = function svg() {
   const sprites = svgstore({
@@ -12,7 +12,7 @@ module.exports = function svg() {
     },
   });
 
-  fs.readdirSync(paths.svg).forEach(file => {
+  fs.readdirSync(paths.get().svg).forEach(file => {
     sprites.add(`i-${file.replace(/\.svg/, "")}`, fs.readFileSync(path.join(paths.svg, file)));
   });
 

--- a/packages/server/lib/services/utils.js
+++ b/packages/server/lib/services/utils.js
@@ -13,7 +13,7 @@ const util = require("util");
 const validate = require("valid-filename");
 const {mkdir, stat, lstat, copyFile, readdir, access} = require("fs").promises;
 
-const paths = require("./paths.js").get();
+const paths = require("./paths.js");
 
 const forceBinaryTypes = [
   "pdf",
@@ -134,19 +134,19 @@ utils.normalizePath = function(p) {
 };
 
 utils.addFilesPath = function(p) {
-  return p === "/" ? paths.files : path.join(`${paths.files}/${p}`);
+  return p === "/" ? paths.get().files : path.join(`${paths.get().files}/${p}`);
 };
 
 utils.removeFilesPath = function(p) {
-  if (p.length > paths.files.length) {
-    return utils.normalizePath(p.substring(paths.files.length));
-  } else if (p === paths.files) {
+  if (p.length > paths.get().files.length) {
+    return utils.normalizePath(p.substring(paths.get().files.length));
+  } else if (p === paths.get().files) {
     return "/";
   }
 };
 
 utils.sanitizePathsInString = function(str) {
-  return (str || "").replace(new RegExp(escapeStringRegexp(paths.files), "g"), "");
+  return (str || "").replace(new RegExp(escapeStringRegexp(paths.get().files), "g"), "");
 };
 
 utils.isPathSane = function(p, isURL) {


### PR DESCRIPTION
Closes: #68

The requires syntax that was used in various modules is problematic because it stores the results of `paths.get()` at import time. This is probably best illustrated with an example:

``` javascript
const paths = require("./paths.js")
const paths2 = require("./paths.js").get();

paths.seed("/a/path/config", "/a/path/file")
console.log(paths.get().config); // <--- /a/path/config
console.log(paths2.config); // <--- !!! returns the default value: the results of resolve(os.homedir()), "/.droppy/config")
// because paths2 is set to the returned object of paths.get() at import time
```