### PR TITLE
Fix uploads race

### DIFF
--- a/packages/server/lib/services/server.js
+++ b/packages/server/lib/services/server.js
@@ -1008,7 +1008,7 @@ function handleUploadRequest(req, res) {
     closeConnection();
   });
 
-  req.on("close", async () => {
+  bb.on("close", async () => {
     if (!done) {
       log.info(req, res, "Upload cancelled");
 


### PR DESCRIPTION
Closes: #87

This took quite a bit to understand what was happening... and ultimately looks like it was a typo. `req.on("close"...` was racing with `bb.on("finish"...`, and it seems that is because `req.on("close"...` should actually be `bb.on("close"...`.

One note about the current setup of `bb.on("finish")` and `bb.on("close")` is that (if I am understanding correctly) it is possible that we would move the temp files into place before the file stream buffer is actually finished/closed. See the [answer ](https://stackoverflow.com/a/32012969 )from mscdex (busboy author).