### PR TITLE
Fix build script

### DIFF
--- a/packages/server/lib/services/svg.js
+++ b/packages/server/lib/services/svg.js
@@ -13,7 +13,7 @@ module.exports = function svg() {
   });
 
   fs.readdirSync(paths.get().svg).forEach(file => {
-    sprites.add(`i-${file.replace(/\.svg/, "")}`, fs.readFileSync(path.join(paths.svg, file)));
+    sprites.add(`i-${file.replace(/\.svg/, "")}`, fs.readFileSync(path.join(paths.get().svg, file)));
   });
 
   return sprites.toString({inline: true});


### PR DESCRIPTION
Fixes a path error in the svg module so that the build script runs now (`DROPPY_CACHE_PATH=$PWD/packages/cli/dist/cache.json lerna run --stream build --`)