### PR TITLE
chore: drop node 14 support, progress towards node 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        node: ["16", "18", "20"]
+        node: ["16", "18", "20", "22"]
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: yarn -s

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        node: ["14", "16", "18", "20"]
+        node: ["16", "18", "20"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -13,23 +13,25 @@
 </p>
 
 ## Features
-* Responsive, scalable HTML5 interface
-* Realtime updates of file system changes
-* Directory and Multi-File upload
-* Drag-and-Drop support
-* Clipboard support to create image/text files
-* Side-by-Side mode
-* Simple and fast Search
-* Shareable public download links
-* Zip download of directories
-* Powerful text editor with themes and broad language support
-* Image and video gallery with touch support
-* Audio player with seeking support
-* Fullscreen support for editor and gallery
-* Supports installing to the homescreen
-* Docker images available for x86-64, ARMv6, ARMv7 and ARMv8
+
+- Responsive, scalable HTML5 interface
+- Realtime updates of file system changes
+- Directory and Multi-File upload
+- Drag-and-Drop support
+- Clipboard support to create image/text files
+- Side-by-Side mode
+- Simple and fast Search
+- Shareable public download links
+- Zip download of directories
+- Powerful text editor with themes and broad language support
+- Image and video gallery with touch support
+- Audio player with seeking support
+- Fullscreen support for editor and gallery
+- Supports installing to the homescreen
+- Docker images available for x86-64, ARMv6, ARMv7 and ARMv8
 
 ## General Information
+
 Two directories will be used, one for configuration and one for the actual files:
 
 - `config`: defaults to `~/.droppy/config`, override with `-c /some/dir`
@@ -38,8 +40,10 @@ Two directories will be used, one for configuration and one for the actual files
 droppy maintains an in-memory representation of the `files` directory. If you're on slow storage and/or serving 100k or more files, the initial indexing on startup will likely take some time.
 
 ## Installation
+
 ### Local Installation :package:
-With [`Node.js`](https://nodejs.org) >= 12.10.0 installed, run:
+
+With [`Node.js`](https://nodejs.org) >= 18.20.4 installed, run:
 
 ```sh
 $ yarn global add @droppyjs/cli
@@ -47,7 +51,7 @@ $ yarn global add @droppyjs/cli
 $ npm install -g @droppyjs/cli
 ```
 
-Then start your server with your configuration options: 
+Then start your server with your configuration options:
 
 ```sh
 $ droppy start -c /srv/droppy/config -f /srv/droppy/files
@@ -57,7 +61,7 @@ $ droppy start -c /srv/droppy/config -f /srv/droppy/files
 To make droppy run in the background, you can use the `--daemon` option, thought it is adviced that you install it as a persistent service in your system. For Linux, see these guides:
 
 - [Systemd-based distributions](https://github.com/silverwind/droppy/wiki/Systemd-Installation)
-- [Debian (Pre-Jessie)](https://github.com/silverwind/droppy/wiki/Debian-Installation-(Pre-Jessie))
+- [Debian (Pre-Jessie)](<https://github.com/silverwind/droppy/wiki/Debian-Installation-(Pre-Jessie)>)
 - [Nginx reverse proxy](https://github.com/silverwind/droppy/wiki/Nginx-reverse-proxy)
 - [Apache reverse proxy](https://github.com/silverwind/droppy/wiki/Apache-reverse-proxy)
 
@@ -89,7 +93,7 @@ $ npm install -g @droppyjs/cli
 
 ### Docker installation :whale:
 
-We currently publish our images to `ghcr.io/droppyjs/droppy`. You can bind columnes /data and /config should you need. 
+We currently publish our images to `ghcr.io/droppyjs/droppy`. You can bind columnes /data and /config should you need.
 
 ### docker-compose
 
@@ -100,6 +104,7 @@ A sample docker-composer file can be found here: https://github.com/droppyjs/dro
 See the example [Caddyfile](examples/Caddyfile).
 
 ## Configuration
+
 By default, the server listens on all IPv4 and IPv6 interfaces on port 8989. On first startup, a prompt to create login data for the first account will appear. Once it's created, login credentials are enforced. Additional accounts can be created in the options interface or the command line. Configuration is done in `config/config.json`, which is created with these defaults:
 
 ```javascript
@@ -129,25 +134,27 @@ By default, the server listens on all IPv4 and IPv6 interfaces on port 8989. On 
 ```
 
 ## Options
-- `listeners` *Array* - Defines on which network interfaces, port and protocols the server will listen. See [listener options](#listener-options) below. `listeners` has no effect when droppy is used as a module. The default listens on HTTP port 8989 on all interfaces and protocols.
-- `public` *boolean* - When enabled, no user authentication is performed. Default: `false`.
-- `timestamps` *boolean* - When enabled, adds timestamps to log output. Default: `true`.
-- `linkLength` *number* - The amount of characters in a shared link. Default: `5`.
-- `linkExtensions` *boolean* - Whether shared links should include the file extension. This can be used to allow other software to make a guess on the content of the file without actually retrieving it. Default: `false`.
-- `logLevel` *number* - Logging amount. `0` is no logging, `1` is errors, `2` is info (HTTP requests), `3` is debug (Websocket communication). Default: `2`.
-- `maxFileSize` *number* - The maximum file size in bytes a user can upload in a single file. `0` means no limit. Default: `0`.
-- `updateInterval` *number* - Interval in milliseconds in which a single client can receive update messages through changes in the file system. Default: `1000`.
-- `pollingInterval` *number* - Interval in milliseconds in which the file system is polled for changes, which **may necessary for files on external or network-mapped drives**. Corresponds to chokidar's [usePolling](https://github.com/paulmillr/chokidar#performance) option. This is CPU-intensive. `0` disables polling. Default: `0`.
-- `keepAlive` *number* - Interval in milliseconds in which the server sends websocket keepalive messages, which may be necessary when proxies are involved. `0` disables keepalive messages. Default: `20000`.
-- `uploadTimeout` *number* - Request timeout for upload requests in milliseconds. Default: `604800000` which is 7 days.
-- `allowFrame` *boolean* - Allow the page to be loaded into a `<frame>` or `<iframe>`. Default: `false`.
-- `readOnly` *boolean* - Treat all files as being read-only. Default: `false`.
-- `dev` *boolean* - Enable developer mode, skipping resource minification and enabling live reload. Default: `false`.
-- `ignorePatterns` *Array* - Array of file path glob patterns to ignore when indexing files. See [here](https://github.com/micromatch/picomatch#globbing-features) for supported patterns. Default: `[]`.
-- `watch` *boolean* - Whether to watch the local file system for changes. Disabling this may improve performance when dealing with a large number of files, but with the downside that changes not done via droppy won't be detected. Default: `true`.
-- `headers` *Object*: A object with key-value pairs of custom HTTP headers to set on all responses, for example `{"Access-Control-Allow-Origin": "*"}`. Default: `{}`.
+
+- `listeners` _Array_ - Defines on which network interfaces, port and protocols the server will listen. See [listener options](#listener-options) below. `listeners` has no effect when droppy is used as a module. The default listens on HTTP port 8989 on all interfaces and protocols.
+- `public` _boolean_ - When enabled, no user authentication is performed. Default: `false`.
+- `timestamps` _boolean_ - When enabled, adds timestamps to log output. Default: `true`.
+- `linkLength` _number_ - The amount of characters in a shared link. Default: `5`.
+- `linkExtensions` _boolean_ - Whether shared links should include the file extension. This can be used to allow other software to make a guess on the content of the file without actually retrieving it. Default: `false`.
+- `logLevel` _number_ - Logging amount. `0` is no logging, `1` is errors, `2` is info (HTTP requests), `3` is debug (Websocket communication). Default: `2`.
+- `maxFileSize` _number_ - The maximum file size in bytes a user can upload in a single file. `0` means no limit. Default: `0`.
+- `updateInterval` _number_ - Interval in milliseconds in which a single client can receive update messages through changes in the file system. Default: `1000`.
+- `pollingInterval` _number_ - Interval in milliseconds in which the file system is polled for changes, which **may necessary for files on external or network-mapped drives**. Corresponds to chokidar's [usePolling](https://github.com/paulmillr/chokidar#performance) option. This is CPU-intensive. `0` disables polling. Default: `0`.
+- `keepAlive` _number_ - Interval in milliseconds in which the server sends websocket keepalive messages, which may be necessary when proxies are involved. `0` disables keepalive messages. Default: `20000`.
+- `uploadTimeout` _number_ - Request timeout for upload requests in milliseconds. Default: `604800000` which is 7 days.
+- `allowFrame` _boolean_ - Allow the page to be loaded into a `<frame>` or `<iframe>`. Default: `false`.
+- `readOnly` _boolean_ - Treat all files as being read-only. Default: `false`.
+- `dev` _boolean_ - Enable developer mode, skipping resource minification and enabling live reload. Default: `false`.
+- `ignorePatterns` _Array_ - Array of file path glob patterns to ignore when indexing files. See [here](https://github.com/micromatch/picomatch#globbing-features) for supported patterns. Default: `[]`.
+- `watch` _boolean_ - Whether to watch the local file system for changes. Disabling this may improve performance when dealing with a large number of files, but with the downside that changes not done via droppy won't be detected. Default: `true`.
+- `headers` _Object_: A object with key-value pairs of custom HTTP headers to set on all responses, for example `{"Access-Control-Allow-Origin": "*"}`. Default: `{}`.
 
 <a name="listener-options"></a>
+
 ### Listener Options
 
 `listeners` defines on which network interfaces, ports and protocol(s) the server will listen. For example:
@@ -169,6 +176,7 @@ By default, the server listens on all IPv4 and IPv6 interfaces on port 8989. On 
   }
 ]
 ```
+
 The above configuration will result in:
 
 - HTTP listening on all IPv4 and IPv6 interfaces, port 80 and on the unix domain socket `/tmp/droppy`.
@@ -176,30 +184,35 @@ The above configuration will result in:
 
 A listener object accepts these options:
 
-- `host` *string/Array* - Network interface(s) addresses to listen on. Required when `port` is given. Note that "::" will typically bind to both IPv4 and IPv6 on all addresses but a "0.0.0.0" address might be required if IPv6 is disabled.
-- `port` *number/string/Array* - Network port(s) to listen on. Required when `host` is given.
-- `socket` *string/Array* - Unix domain socket(s) to listen on.
-- `protocol` *string* - Protocol to use, `http` or `https`. Required.
+- `host` _string/Array_ - Network interface(s) addresses to listen on. Required when `port` is given. Note that "::" will typically bind to both IPv4 and IPv6 on all addresses but a "0.0.0.0" address might be required if IPv6 is disabled.
+- `port` _number/string/Array_ - Network port(s) to listen on. Required when `host` is given.
+- `socket` _string/Array_ - Unix domain socket(s) to listen on.
+- `protocol` _string_ - Protocol to use, `http` or `https`. Required.
 
 For TLS the following additional options are available. Paths can be given relative to the configuration directory and `~` is resolved as expected.
 
-- `cert` *string* - Path to PEM-encoded TLS certificate file, which can include additional intermediate certificates concatenated after the main certificate. Required.
-- `key` *string* - Path to PEM-encoded TLS private key file not encrypted with a passphrase. Required.
+- `cert` _string_ - Path to PEM-encoded TLS certificate file, which can include additional intermediate certificates concatenated after the main certificate. Required.
+- `key` _string_ - Path to PEM-encoded TLS private key file not encrypted with a passphrase. Required.
 
 ## Downloading from the command line
+
 To download shared links with `curl` and `wget` to the correct filename:
-````sh
+
+```sh
 $ curl -OJ url
 $ wget --content-disposition url
-````
+```
 
 # Development
+
 To start a live-reloading dev server:
-````sh
+
+```sh
 $ git clone https://github.com/droppyjs/droppy && cd droppy
 $ lerna bootstrap
 $ yarn start
-````
+```
+
 The [Makefile](https://github.com/droppyjs/droppy/blob/master/Makefile) has a few old tasks for updating dependencies, pushing docker images, see the comment above for dependencies of those tasks. This should not be required anymore, but is left as a reference.
 
 © [Mark Hughes](https://github.com/droppyjs), [silverwind](https://github.com/silverwind), distributed under BSD licence.

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     ],
     "browserslist": "defaults",
     "volta": {
-        "node": "14.21.3",
+        "node": "18.20.4",
         "yarn": "1.22.10"
     },
     "lint-staged": {


### PR DESCRIPTION
Closes: ??

### What are the changes and their implications?

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [droppyjs.com](https://github.com/droppyjs/droppyjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
