### PR TITLE
fix: removing filetree callback hell

### DIFF
--- a/packages/server/lib/commands/clipboard.js
+++ b/packages/server/lib/commands/clipboard.js
@@ -10,9 +10,17 @@ export default {
     const src = msg.data.src;
     const dst = msg.data.dst;
     const type = msg.data.type;
+
     log.info(ws, null, `Clipboard ${type}: ${src} -> ${dst}`);
-    if (config.readOnly) return sendError(sid, vId, "Files are read-only");
-    if (!validatePaths([src, dst], msg.type, ws, sid, vId)) return;
+
+    if (config.readOnly) {
+      return sendError(sid, vId, "Files are read-only");
+    }
+
+    if (!validatePaths([src, dst], msg.type, ws, sid, vId)) {
+      return;
+    }
+
     if (new RegExp(`^${escRe(msg.data.src)}/`).test(msg.data.dst)) {
       return sendError(sid, vId, "Can't copy directory into itself");
     }

--- a/packages/server/lib/commands/createFile.js
+++ b/packages/server/lib/commands/createFile.js
@@ -8,8 +8,12 @@ export default {
     if (!validatePaths(msg.data, msg.type, ws, sid, vId)) {
       return;
     }
-    filetree.mk(msg.data, (err) => {
-      if (err) sendError(sid, vId, `Error creating file: ${err.message}`);
-    });
+
+    try {
+      await filetree.mk(msg.data);
+    } catch (err) {
+      log.error(ws, null, err);
+      sendError(sid, vId, `Error creating file: ${err.message}`);
+    }
   },
 };

--- a/packages/server/lib/commands/createFiles.js
+++ b/packages/server/lib/commands/createFiles.js
@@ -13,18 +13,14 @@ export default {
       return;
     }
 
-    await Promise.all(
-      msg.data.files.map((file) => {
-        return new Promise((resolve) => {
-          filetree.mkdir(utils.addFilesPath(path.dirname(file)), (err) => {
-            if (err) log.error(ws, null, err);
-            filetree.mk(utils.addFilesPath(file), (err) => {
-              if (err) log.error(ws, null, err);
-              resolve();
-            });
-          });
-        });
-      })
-    );
+    for (const file of msg.data.files) {
+      try {
+        await filetree.mkdir(utils.addFilesPath(path.dirname(file)));
+        await filetree.mk(utils.addFilesPath(file));
+      } catch (err) {
+        log.error(ws, null, err);
+        sendError(sid, vId, `Error creating file`);
+      }
+    }
   },
 };

--- a/packages/server/lib/commands/createFolder.js
+++ b/packages/server/lib/commands/createFolder.js
@@ -1,4 +1,5 @@
 import filetree from "../services/filetree.js";
+import log from "../services/log.js";
 
 export default {
   handler: async ({ validatePaths, sid, config, msg, ws, vId, sendError }) => {
@@ -9,8 +10,11 @@ export default {
       return;
     }
 
-    filetree.mkdir(msg.data, (err) => {
-      if (err) sendError(sid, vId, `Error creating folder: ${err.message}`);
-    });
+    try {
+      await filetree.mkdir(msg.data);
+    } catch (err) {
+      log.error(ws, null, err);
+      sendError(sid, vId, `Error creating folder: ${err.message}`);
+    }
   },
 };

--- a/packages/server/lib/commands/createFolders.js
+++ b/packages/server/lib/commands/createFolders.js
@@ -12,17 +12,13 @@ export default {
       return;
     }
 
-    await Promise.all(
-      msg.data.folders.map((folder) => {
-        return new Promise((resolve) => {
-          filetree.mkdir(utils.addFilesPath(folder), (err) => {
-            if (err) {
-              log.error(ws, null, err);
-            }
-            resolve();
-          });
-        });
-      })
-    );
+    for (const folder of msg.data.folders) {
+      try {
+        await filetree.mkdir(utils.addFilesPath(folder));
+      } catch (err) {
+        log.error(ws, null, err);
+        sendError(sid, vId, `Error creating folder ${folder}`);
+      }
+    }
   },
 };

--- a/packages/server/lib/commands/deleteFile.js
+++ b/packages/server/lib/commands/deleteFile.js
@@ -12,6 +12,13 @@ export default {
       return;
     }
     log.info(ws, null, `Deleting: ${msg.data}`);
-    filetree.del(msg.data);
+
+    try {
+      await filetree.del(msg.data);
+    } catch (err) {
+      log.info(ws, null, `Error deleting file: ${msg.data}`);
+      log.error(err);
+      return sendError(sid, vId, "Error deleting file");
+    }
   },
 };

--- a/packages/server/lib/commands/rename.js
+++ b/packages/server/lib/commands/rename.js
@@ -23,7 +23,14 @@ export default {
       sendError(sid, vId, "Invalid rename request");
       return;
     }
-    filetree.move(rSrc, rDst);
+
+    try {
+      await filetree.move(rSrc, rDst);
+    } catch (err) {
+      log.error(ws, null, err);
+      sendError(sid, vId, `Error renaming ${rSrc} to ${rDst}`);
+      return;
+    }
 
     // update sharelinks to new destination
     const links = db.get("links");

--- a/packages/server/lib/commands/saveFile.js
+++ b/packages/server/lib/commands/saveFile.js
@@ -23,11 +23,15 @@ export default {
 
     log.info(ws, null, `Saving: ${msg.data.to}`);
 
-    filetree.save(msg.data.to, msg.data.value, (err) => {
-      if (err) {
-        sendError(sid, vId, `Error saving: ${err.message}`);
-        log.error(err);
-      } else sendObj(sid, { type: "SAVE_STATUS", vId, status: err ? 1 : 0 });
-    });
+    try {
+      await filetree.save(msg.data.to, msg.data.value);
+    } catch (err) {
+      sendObj(sid, { type: "SAVE_STATUS", vId, status: 1 });
+      sendError(sid, vId, `Error saving: ${err.message}`);
+      log.error(err);
+      return;
+    }
+
+    sendObj(sid, { type: "SAVE_STATUS", vId, status: 0 });
   },
 };

--- a/packages/server/lib/services/utils.js
+++ b/packages/server/lib/services/utils.js
@@ -55,7 +55,9 @@ class DroppyUtils {
     for (const d of Array.isArray(dir) ? dir : [dir]) {
       await mkdir(d, { mode: "755", recursive: true });
     }
-    cb();
+    if (cb) {
+      cb();
+    }
   }
 
   rm(p, cb) {


### PR DESCRIPTION
Closes: ??

### What are the changes and their implications?

Removes callback hell from filetree, moves to promises 

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [droppyjs.com](https://github.com/droppyjs/droppyjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
