### PR TITLE
Update `/data` volume to `/files`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ npm install -g @droppyjs/cli
 
 ### Docker installation :whale:
 
-We currently publish our images to `ghcr.io/droppyjs/droppy`. You can bind volumes `/data` and `/config` should you need.
+We currently publish our images to `ghcr.io/droppyjs/droppy`. You can bind volumes `/files` and `/config` should you need.
 
 ### docker-compose
 


### PR DESCRIPTION
### What are the changes and their implications?

Updated README.md to use `/files` volume instead of `/data`.

The Docker image looks for files at `/files` not `/data`.

### Checklist

- [x] Changes covered by tests (tests added if needed)
- [x] PR submitted to [droppyjs.com](https://github.com/droppyjs/droppyjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
