### PR TITLE
fix(#119): bin file should be mjs

### DIFF
--- a/packages/cli/bin/droppy.mjs
+++ b/packages/cli/bin/droppy.mjs
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 
-const { realpathSync, existsSync } = require("fs");
-const path = require("path");
+import { realpathSync, existsSync } from "fs";
+import { join, dirname } from "path";
+
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Check for DROPPY_CACHE_PATH, otherwise add default.
 if (!("DROPPY_CACHE_PATH" in process.env)) {
   const cachePath = realpathSync(
-    path.join(__dirname, "..", "dist", "cache.json")
+    join(__dirname, "..", "dist", "cache.json")
   );
   if (existsSync(cachePath)) {
     process.env.DROPPY_CACHE_PATH = cachePath;
@@ -18,4 +23,4 @@ if (!("DROPPY_CACHE_SKIP_VALIDATIONS" in process.env)) {
   process.env.DROPPY_CACHE_SKIP_VALIDATIONS = true;
 }
 
-require("../lib/cli");
+import("../lib/cli.js");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
         "hosted"
     ],
     "bin": {
-        "droppy": "bin/droppy"
+        "droppy": "bin/droppy.mjs"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Closes: #119

### What are the changes and their implications?

Fixes mjs support to bin file 

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [droppyjs.com](https://github.com/droppyjs/droppyjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
