### PR TITLE
fix(#131): add missing build step for new structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ COPY . /droppy
 RUN rm -rf /droppy/node_modules && \
     cd /droppy && \
     corepack enable && \
-    yarn install --immutable
+    yarn install --immutable && \
+    yarn build
 
 
 # -------------------------------------------------- #


### PR DESCRIPTION
Closes: #131 

### What are the changes and their implications?

Adds build step for new structure (dockerfile was neglected) 

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [droppyjs.com](https://github.com/droppyjs/droppyjs.com) for any user facing changes

<!-- IMPORTANT: Make sure to check the "Allow edits from maintainers" box below this window -->
