### PR TITLE
Preserve search results after directory changes

### DIFF
--- a/packages/client/lib/client.js
+++ b/packages/client/lib/client.js
@@ -400,7 +400,11 @@ function openSocket() {
                     }
                     view[0].switchRequest = false;
                     view[0].currentData = msg.data;
-                    openDirectory(view, view[0].currentData);
+                    if (hasActiveSearch(view, msg.folder)) {
+                        sendSearch(view);
+                    } else {
+                        openDirectory(view, view[0].currentData);
+                    }
                 } else if (view[0].dataset.type === "media") {
                     view[0].currentData = msg.data;
                     // TODO: Update media array
@@ -481,6 +485,7 @@ function openSocket() {
                 break;
             }
             case "SEARCH_RESULTS": {
+                if (!hasActiveSearch(view, msg.folder, msg.query)) break;
                 openDirectory(view, msg.results, true);
                 break;
             }
@@ -523,6 +528,38 @@ function sendMessage(vId, type, data) {
             openSocket();
         }
     }
+}
+
+function hasActiveSearch(view, folder, query) {
+    const search = view[0].activeSearch;
+    if (!search?.query) return false;
+    if (folder !== undefined && search.folder !== folder) return false;
+    if (query !== undefined && search.query !== query) return false;
+    return true;
+}
+
+function sendSearch(view, query) {
+    query = query ?? view[0].activeSearch?.query;
+    if (!query || !String(query).trim()) return false;
+
+    view[0].activeSearch = {
+        folder: view[0].currentFolder,
+        query,
+    };
+
+    sendMessage(view[0].vId, "SEARCH", {
+        query,
+        dir: view[0].currentFolder,
+    });
+    return true;
+}
+
+function restoreSearch(view) {
+    const input = view.find(".search input")[0];
+    if (!input || !hasActiveSearch(view, view[0].currentFolder)) return;
+
+    view.find(".search").removeClass("toggled-off").addClass("toggled-on");
+    input.value = view[0].activeSearch.query;
 }
 
 // ============================================================================
@@ -1253,7 +1290,11 @@ function openDirectory(view, data, isSearch) {
     let entries = getTemplateEntries(view, data ?? []);
     view[0].templateEntries = entries;
 
-    clearSearch(view);
+    if (isSearch) {
+        restoreSearch(view);
+    } else {
+        clearSearch(view);
+    }
 
     // sorting
     const sortings = droppy.get("sortings");
@@ -1910,10 +1951,7 @@ function initButtons(view) {
     // Search Box
     function doSearch(e) {
         if (e.target.value && String(e.target.value).trim()) {
-            sendMessage(view[0].vId, "SEARCH", {
-                query: e.target.value,
-                dir: view[0].currentFolder,
-            });
+            sendSearch(view, e.target.value);
         } else {
             openDirectory(view, view[0].currentData);
         }
@@ -2137,7 +2175,8 @@ function saveFile(text, filename) {
     setTimeout(() => document.body.removeChild(a), 0);
 }
 
-function clearSearch(view) {
+function clearSearch(view, options) {
+    if (!options?.keepState) view[0].activeSearch = null;
     if (!view.find(".search-input").is(":focus")) {
         view.find(".search").removeClass("toggled-on").addClass("toggled-off");
         view.find(".search input")[0].value = null;
@@ -2205,7 +2244,7 @@ function closeDoc(view) {
 
 function openFile(view, newFolder, file, opts) {
     opts = opts || {};
-    clearSearch(view);
+    clearSearch(view, { keepState: true });
     const e = fileExtension(file);
 
     // Fix newFolder and file variables if file includes the dir path

--- a/packages/server/src/commands/search.ts
+++ b/packages/server/src/commands/search.ts
@@ -22,6 +22,7 @@ export default createCommand<SearchMessage>(
             type: "SEARCH_RESULTS",
             vId,
             folder: dir,
+            query,
             results: await storage.search(query, dir),
         });
     },


### PR DESCRIPTION
Closes: #18

### What are the changes and their implications?

This keeps per-view search state for the active query/folder. When a directory update arrives after a file operation, droppy now re-runs the active search instead of replacing the results with the full directory listing. Search results also restore the search input state, and opening a file preserves the active search so browser Back can return to the filtered result list.

The search response now echoes the query so the client can ignore stale results when a newer query is active.

### Verification

- `git diff --check`
- `yarn lint` (passes; reports existing warnings)
- `yarn biome check packages/client/lib/client.js packages/server/src/commands/search.ts` (passes; reports existing unused `normalize` warning in `client.js`)
- `yarn workspace @droppyjs/server build`
- `yarn test`

`yarn build` was attempted, but the existing resource build fails looking for workspace-local client dependency paths such as `node_modules/handlebars/dist/handlebars.runtime.min.js` under the client package.

### Checklist

- [ ] Changes covered by tests (tests added if needed)
- [ ] PR submitted to [droppyjs.com](https://github.com/droppyjs/droppyjs.com) for any user facing changes
